### PR TITLE
Allow persistent connection option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .bundle/
+vendor/
 .yardoc
 _yardoc/
 coverage/

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ conn = Faraday.new(...) do |f|
 end
 ```
 
+Passing connection options:
+```ruby
+conn = Faraday.new(...) do |f|
+  # Will keep the connection memoized within the adapter, and rely that flag to excon
+  f.adapter :excon, persistent: true
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -15,6 +15,24 @@ RSpec.describe Faraday::Adapter::Excon do
     expect(conn.data[:debug_request]).to be_truthy
   end
 
+  context 'build_connection' do
+    let(:adapter) { Faraday::Adapter::Excon.new }
+    let(:request) { Faraday::RequestOptions.new }
+    let(:uri) { URI.parse('https://example.com') }
+    let(:env) { { request: request, url: uri } }
+
+    it 'uses a new connection when the adapter is not persistent' do
+      conn1 = adapter.connection(env).object_id
+      expect(adapter.connection(env).object_id).to_not eq(conn1)
+    end
+
+    it 're-uses the same connection when the adapter is persistent' do
+      adapter = Faraday::Adapter::Excon.new(nil, persistent: true)
+      conn1 = adapter.connection(env).object_id
+      expect(adapter.connection(env).object_id).to eq(conn1)
+    end
+  end
+
   context 'config' do
     let(:adapter) { Faraday::Adapter::Excon.new }
     let(:request) { Faraday::RequestOptions.new }

--- a/spec/faraday/adapter/excon_spec.rb
+++ b/spec/faraday/adapter/excon_spec.rb
@@ -22,14 +22,14 @@ RSpec.describe Faraday::Adapter::Excon do
     let(:env) { { request: request, url: uri } }
 
     it 'uses a new connection when the adapter is not persistent' do
-      conn1 = adapter.connection(env).object_id
-      expect(adapter.connection(env).object_id).to_not eq(conn1)
+      conn1 = adapter.connection(env)
+      expect(adapter.connection(env)).to_not be(conn1)
     end
 
     it 're-uses the same connection when the adapter is persistent' do
       adapter = Faraday::Adapter::Excon.new(nil, persistent: true)
-      conn1 = adapter.connection(env).object_id
-      expect(adapter.connection(env).object_id).to eq(conn1)
+      conn1 = adapter.connection(env)
+      expect(adapter.connection(env)).to be(conn1)
     end
   end
 


### PR DESCRIPTION
Excon allows a connection flag to keep the socket open (for the current thread). That flag is called `persistent: true`. See docs https://github.com/excon/excon

This changes the Faraday adapter a bit, to make sure we will memoize the connection when that flag is passed. 

cc @brasic 