### PR TITLE
gemspec: Require faraday ~> 2.0

### DIFF
--- a/faraday-excon.gemspec
+++ b/faraday-excon.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'excon', '>= 0.27.4'
-  spec.add_dependency 'faraday', '~> 2.0.0.alpha-2'
+  spec.add_dependency 'faraday', '~> 2.0'
 end


### PR DESCRIPTION
The previous value was from an era long ago.